### PR TITLE
Final class date change 

### DIFF
--- a/Fundamentals_Syllabus.Rmd
+++ b/Fundamentals_Syllabus.Rmd
@@ -76,7 +76,7 @@ This course is being taught through a synchronous remote modality through Zoom. 
 |:--------------------|:--------------------------|
 |January 1 (Tuesday):  | First day of Spring courses | 
 |January 15 (Monday):| Martin Luther King Jr. Day (no class)      | 
-|February 19 (Wednesday): | Last day of class  | 
+|February 18 (Wednesday): | Last day of class  | 
 -->
 
 ### WORKLOAD:

--- a/Fundamentals_Syllabus.Rmd
+++ b/Fundamentals_Syllabus.Rmd
@@ -76,7 +76,7 @@ This course is being taught through a synchronous remote modality through Zoom. 
 |:--------------------|:--------------------------|
 |January 1 (Tuesday):  | First day of Spring courses | 
 |January 15 (Monday):| Martin Luther King Jr. Day (no class)      | 
-|February 21 (Wednesday): | Last day of class  | 
+|February 19 (Wednesday): | Last day of class  | 
 -->
 
 ### WORKLOAD:


### PR DESCRIPTION
Hello Dr Johnson,

I notice a typo in the date for the final class in the some IMPORTANT DATES section for the Fundamental.Syllabus HTML file. Originally, it said it was Feb 21, but that is a Saturday, which doesn't align with our current class schedule. So I change the date from Feb 21 to Feb 18, as that is more accurate and it follows our course outline. 

Best, 
Prem Patel 